### PR TITLE
Add typed API route for substitution data

### DIFF
--- a/src/app/api/substitution/route.ts
+++ b/src/app/api/substitution/route.ts
@@ -1,0 +1,12 @@
+import { NextRequest, NextResponse } from "next/server";
+import { fetchSubstitutions, SubstitutionRequest } from "@/lib/getSubstitutions";
+
+export async function POST(req: NextRequest) {
+  const body: SubstitutionRequest = await req.json();
+  try {
+    const data = await fetchSubstitutions(body);
+    return NextResponse.json(data);
+  } catch (error) {
+    return NextResponse.json({ error: (error as Error).message }, { status: 500 });
+  }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,213 +1,65 @@
-"use client";
-import Script from "next/script";
+import {
+  fetchSubstitutions,
+  SubstitutionRequest,
+  SubstitutionResponse,
+} from "@/lib/getSubstitutions";
 
-const showLegal = (page: string) => {
-  (window as unknown as { showLegalPage?: (p: string) => void }).showLegalPage?.(
-    page
-  );
+const request: SubstitutionRequest = {
+  formatName: "Web-Schüler-heute",
+  schoolName: "dessauer-schule-limburg",
+  date: 20250508,
+  dateOffset: 0,
+  activityTypeIds: [],
+  departmentElementType: -1,
+  departmentIds: [],
+  enableSubstitutionFrom: false,
+  groupBy: 1,
+  hideAbsent: false,
+  hideCancelCausedByEvent: false,
+  hideCancelWithSubstitution: true,
+  mergeBlocks: true,
+  showAbsentElements: [],
+  showAbsentTeacher: true,
+  showAffectedElements: [1],
+  showBreakSupervisions: false,
+  showCancel: true,
+  showClass: true,
+  showEvent: true,
+  showExamSupervision: false,
+  showHour: true,
+  showInfo: true,
+  showMessages: true,
+  showOnlyCancel: false,
+  showOnlyFutureSub: true,
+  showRoom: true,
+  showStudentgroup: false,
+  showSubject: true,
+  showSubstText: true,
+  showSubstTypeColor: false,
+  showSubstitutionFrom: 0,
+  showTeacher: true,
+  showTeacherOnEvent: false,
+  showTime: true,
+  showUnheraldedExams: false,
+  showUnitTime: false,
+  strikethrough: true,
+  strikethroughAbsentTeacher: true,
 };
 
-const goToMain = () => {
-  (window as unknown as { goToMainPage?: () => void }).goToMainPage?.();
-};
+export default async function Home() {
+  let data: SubstitutionResponse | null = null;
+  try {
+    data = await fetchSubstitutions(request);
+  } catch (error) {
+    console.error(error);
+  }
 
-const dismissWelcome = () => {
-  (window as unknown as { dismissWelcome?: () => void }).dismissWelcome?.();
-};
-
-export default function Home() {
   return (
-    <>
-      <Script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js" />
-      <Script src="https://unpkg.com/lucide@latest/dist/umd/lucide.js" />
-      <div id="welcome-overlay" className="welcome-overlay hidden">
-        <div className="welcome-content">
-          <h2>Willkommen zum Vertretungsplan!</h2>
-          <p>
-            Hier finden Sie alle aktuellen Vertretungen und Änderungen für Ihre
-            Klasse.
-          </p>
-          <button className="btn btn--primary" onClick={dismissWelcome}>Los geht&apos;s!</button>
-        </div>
-      </div>
-
-      <div id="mobile-menu-overlay" className="mobile-menu-overlay hidden">
-        <div className="mobile-menu">
-          <div className="mobile-menu-header">
-            <h3>Menü</h3>
-            <button id="close-mobile-menu" className="mobile-menu-close">
-              <i data-lucide="x"></i>
-            </button>
-          </div>
-          <div className="mobile-menu-content">
-            <div className="calendar-widget">
-              <h4>Datum auswählen</h4>
-              <div className="calendar-container">
-                <div className="calendar-header">
-                  <button id="prev-month-mobile" className="calendar-nav">
-                    <i data-lucide="chevron-left"></i>
-                  </button>
-                  <span id="current-month-mobile" className="calendar-month" />
-                  <button id="next-month-mobile" className="calendar-nav">
-                    <i data-lucide="chevron-right"></i>
-                  </button>
-                </div>
-                <div id="calendar-mobile" className="calendar-grid" />
-              </div>
-            </div>
-
-            <button id="show-substitutions-mobile" className="btn btn--primary btn--full-width">
-              <span className="button-text">Vertretungen anzeigen</span>
-              <span className="loading-spinner hidden">
-                <i data-lucide="loader-2"></i>
-              </span>
-            </button>
-
-            <div className="search-container">
-              <div className="search-input-wrapper">
-                <i data-lucide="search" className="search-icon"></i>
-                <input
-                  type="text"
-                  id="search-input-mobile"
-                  className="form-control search-input"
-                  placeholder="Klasse, Lehrer, Fach oder Raum suchen..."
-                />
-              </div>
-            </div>
-
-            <div className="filter-section">
-              <h4>Kategorien</h4>
-              <div id="category-filters-mobile" className="category-filters" />
-            </div>
-
-            <div className="legal-links">
-              <a href="#impressum" onClick={() => showLegal('impressum')}>Impressum</a>
-              <a href="#datenschutz" onClick={() => showLegal('datenschutz')}>Datenschutz</a>
-            </div>
-          </div>
-        </div>
-      </div>
-
-      <div className="app-layout">
-        <header className="app-header">
-          <div className="header-content">
-            <button id="mobile-menu-toggle" className="mobile-menu-toggle">
-              <i data-lucide="menu"></i>
-            </button>
-              <h1
-                className="app-title clickable-title"
-                onClick={goToMain}
-              tabIndex={0}
-              role="button"
-              aria-label="Zur Hauptseite"
-            >
-              Vertretungsplan
-            </h1>
-            <div className="header-actions">
-              <nav className="header-nav">
-                  <a href="#impressum" onClick={() => showLegal('impressum')}>Impressum</a>
-                  <a href="#datenschutz" onClick={() => showLegal('datenschutz')}>Datenschutz</a>
-              </nav>
-              <button id="theme-toggle" className="theme-toggle">
-                <i data-lucide="sun" className="theme-icon theme-icon--light"></i>
-                <i data-lucide="moon" className="theme-icon theme-icon--dark"></i>
-                <i data-lucide="monitor" className="theme-icon theme-icon--system"></i>
-              </button>
-            </div>
-          </div>
-        </header>
-
-        <div className="app-content">
-          <aside className="sidebar">
-            <div className="calendar-widget">
-              <h3>Datum auswählen</h3>
-              <div className="calendar-container">
-                <div className="calendar-header">
-                  <button id="prev-month" className="calendar-nav">
-                    <i data-lucide="chevron-left"></i>
-                  </button>
-                  <span id="current-month" className="calendar-month" />
-                  <button id="next-month" className="calendar-nav">
-                    <i data-lucide="chevron-right"></i>
-                  </button>
-                </div>
-                <div id="calendar" className="calendar-grid" />
-              </div>
-            </div>
-
-            <button id="show-substitutions" className="btn btn--primary btn--full-width">
-              <span className="button-text">Vertretungen anzeigen</span>
-              <span className="loading-spinner hidden">
-                <i data-lucide="loader-2"></i>
-              </span>
-            </button>
-
-            <div className="search-container">
-              <div className="search-input-wrapper">
-                <i data-lucide="search" className="search-icon"></i>
-                <input
-                  type="text"
-                  id="search-input"
-                  className="form-control search-input"
-                  placeholder="Klasse, Lehrer, Fach oder Raum suchen..."
-                />
-              </div>
-            </div>
-
-            <div className="filter-section">
-              <h3>Kategorien</h3>
-              <div id="category-filters" className="category-filters" />
-            </div>
-          </aside>
-
-          <main className="main-content">
-            <div id="main-view" className="main-view">
-              <div className="content-header">
-                <h2 id="content-title">Vertretungen für heute</h2>
-                <div id="search-results-info" className="search-results-info hidden"></div>
-              </div>
-
-              <div id="loading-state" className="loading-state hidden">
-                <div className="skeleton-cards">
-                  <div className="skeleton-card"></div>
-                  <div className="skeleton-card"></div>
-                  <div className="skeleton-card"></div>
-                  <div className="skeleton-card"></div>
-                </div>
-              </div>
-
-              <div id="error-state" className="error-state hidden">
-                <div className="error-message">
-                  <i data-lucide="alert-circle"></i>
-                  <h3>Fehler beim Laden der Vertretungen</h3>
-                  <p id="error-text">Es ist ein Fehler aufgetreten. Bitte versuchen Sie es erneut.</p>
-                  <button id="retry-button" className="btn btn--primary">Erneut versuchen</button>
-                </div>
-              </div>
-
-              <div id="substitutions-grid" className="substitutions-grid"></div>
-
-              <div id="no-results" className="no-results hidden">
-                <i data-lucide="search"></i>
-                <h3>Keine Vertretungen gefunden</h3>
-                <p>Für die gewählten Filter wurden keine Vertretungen gefunden.</p>
-              </div>
-            </div>
-
-            <div id="legal-view" className="legal-view hidden">
-              <div className="legal-header">
-                <button id="back-to-main" className="btn btn--outline">
-                  <i data-lucide="arrow-left"></i>
-                  Zurück
-                </button>
-              </div>
-              <div id="legal-content" className="legal-content"></div>
-            </div>
-          </main>
-        </div>
-      </div>
-
-      <Script src="/app.js"></Script>
-    </>
+    <main className="p-4">
+      <h1 className="text-xl font-semibold mb-4">Vertretungsplan</h1>
+      <pre className="whitespace-pre-wrap break-all bg-gray-100 p-4 rounded">
+        {JSON.stringify(data, null, 2)}
+      </pre>
+    </main>
   );
 }

--- a/src/lib/getSubstitutions.ts
+++ b/src/lib/getSubstitutions.ts
@@ -1,0 +1,70 @@
+export interface SubstitutionRequest {
+  formatName: string;
+  schoolName: string;
+  date: number;
+  dateOffset: number;
+  activityTypeIds: number[];
+  departmentElementType: number;
+  departmentIds: number[];
+  enableSubstitutionFrom: boolean;
+  groupBy: number;
+  hideAbsent: boolean;
+  hideCancelCausedByEvent: boolean;
+  hideCancelWithSubstitution: boolean;
+  mergeBlocks: boolean;
+  showAbsentElements: string[];
+  showAbsentTeacher: boolean;
+  showAffectedElements: number[];
+  showBreakSupervisions: boolean;
+  showCancel: boolean;
+  showClass: boolean;
+  showEvent: boolean;
+  showExamSupervision: boolean;
+  showHour: boolean;
+  showInfo: boolean;
+  showMessages: boolean;
+  showOnlyCancel: boolean;
+  showOnlyFutureSub: boolean;
+  showRoom: boolean;
+  showStudentgroup: boolean;
+  showSubject: boolean;
+  showSubstText: boolean;
+  showSubstTypeColor: boolean;
+  showSubstitutionFrom: number;
+  showTeacher: boolean;
+  showTeacherOnEvent: boolean;
+  showTime: boolean;
+  showUnheraldedExams: boolean;
+  showUnitTime: boolean;
+  strikethrough: boolean;
+  strikethroughAbsentTeacher: boolean;
+}
+
+export interface SubstitutionResponse {
+  payload: unknown;
+}
+
+const endpoint =
+  "https://hepta.webuntis.com/WebUntis/monitor/substitution/data?school=dessauer-schule-limburg";
+
+export async function fetchSubstitutions(
+  request: SubstitutionRequest,
+): Promise<SubstitutionResponse> {
+  const res = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      // The cookie values are taken from request.txt; real values may be required
+      Cookie:
+        'Tenant-Id="3997500"; schoolname="_ZGVzc2F1ZXItc2NodWxlLWxpbWJ1cmc="; traceId=3b59a82c796cea6bfe3d547b9405e8f539e1685f; JSESSIONID=E0947AF95D687146598597C829F2EF09',
+    },
+    body: JSON.stringify(request),
+    redirect: "follow",
+  });
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch substitutions: ${res.status}`);
+  }
+
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- add TypeScript request helper for WebUntis
- expose `/api/substitution` route
- simplify page to fetch and render substitution data

## Testing
- `npm run lint`
- `npm run build` *(fails to fetch due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6845fa58d9f8832ca12f6637b510a7ea